### PR TITLE
update `pbkdf2-sha512.c` hash

### DIFF
--- a/pbkdf2-sha512/default.nix
+++ b/pbkdf2-sha512/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     
   src = fetchurl {
     url = "https://raw.githubusercontent.com/NixOS/nixpkgs/master/nixos/modules/system/boot/pbkdf2-sha512.c";
-    sha256 = "0pn5hh78pyh4q6qjp3abipivkgd8l39sqg5jnawz66bdzicag4l7";
+    sha256 = "0ky414spzpndiifk7wca3q3l9gzs1ksn763dmy48xdn3q0i75s9r";
   };
 
   unpackPhase = ":";


### PR DESCRIPTION
seems the file changed here: https://github.com/NixOS/nixpkgs/commit/88bf1b3e92d96cb64c862db09b7e90263d89664e#diff-928863deda3fc33e0506277ded7f4985a078c4bd878489b10f9d5f2343bb8da7

we could also use a branch other than master, to avoid future changes. but seems like they don't happen too often!